### PR TITLE
Load classes from their origin classloader

### DIFF
--- a/src/main/java/fr/insalyon/telecom/jooflux/InvokeBootstrap.java
+++ b/src/main/java/fr/insalyon/telecom/jooflux/InvokeBootstrap.java
@@ -30,7 +30,7 @@ public class InvokeBootstrap {
         Logger.info("lookup=" + lookup + ", name=" + name + ", type=" + type + ", args=" + Arrays.toString(args));
         try {
             MethodHandle methodHandle = lookup.findConstructor(
-                    Class.forName(extractPackageName(name)),
+                    classDefinition(lookup, extractPackageName(name)),
                     type.changeReturnType(void.class)
             );
             totalInitialMethodInterception++;
@@ -46,7 +46,7 @@ public class InvokeBootstrap {
         Logger.info("lookup=" + lookup + ", name=" + name + ", type=" + type + ", args=" + Arrays.toString(args));
         try {
             MethodHandle methodHandle = lookup.findStatic(
-                    Class.forName(extractPackageName(name)),
+                    classDefinition(lookup, extractPackageName(name)),
                     extractMethodName(name),
                     type
             );
@@ -63,7 +63,7 @@ public class InvokeBootstrap {
         Logger.info("lookup=" + lookup + ", name=" + name + ", type=" + type + ", args=" + Arrays.toString(args));
         try {
             MethodHandle methodHandle = lookup.findVirtual(
-                    Class.forName(extractPackageName(name)),
+                    classDefinition(lookup, extractPackageName(name)),
                     extractMethodName(name),
                     type.dropParameterTypes(0, 1)
             );
@@ -80,7 +80,7 @@ public class InvokeBootstrap {
         Logger.info("lookup=" + lookup + ", name=" + name + ", type=" + type + ", args=" + Arrays.toString(args));
         try {
             MethodHandle methodHandle = lookup.findVirtual(
-                    Class.forName(extractPackageName(name)),
+                    classDefinition(lookup, extractPackageName(name)),
                     extractMethodName(name),
                     type.dropParameterTypes(0, 1)
             );
@@ -96,7 +96,7 @@ public class InvokeBootstrap {
     public static CallSite dynvokeSpecial(MethodHandles.Lookup lookup, String name, MethodType type, Object... args) throws NoSuchMethodException, IllegalAccessException, ClassNotFoundException {
         Logger.info("lookup=" + lookup + ", name=" + name + ", type=" + type + ", args=" + Arrays.toString(args));
         try {
-            Class<?> packageClass = Class.forName(extractPackageName(name));
+            Class<?> packageClass = classDefinition(lookup, extractPackageName(name));
             MethodHandle methodHandle = lookup.findSpecial(
                     packageClass,
                     extractMethodName(name),

--- a/src/main/java/fr/insalyon/telecom/jooflux/internal/JooFluxUtils.java
+++ b/src/main/java/fr/insalyon/telecom/jooflux/internal/JooFluxUtils.java
@@ -16,6 +16,7 @@ import org.pmw.tinylog.Logger;
 
 import java.lang.invoke.CallSite;
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VolatileCallSite;
 import java.util.HashMap;
 import java.util.Map;
@@ -27,6 +28,11 @@ public class JooFluxUtils {
     public static boolean INTERCEPT_INVOKEVIRTUAL = true;
     public static boolean INTERCEPT_INVOKEINTERFACE = false;
     public static boolean INTERCEPT_INVOKESPECIAL = false;
+
+    public static Class<?> classDefinition(MethodHandles.Lookup lookup, String name) throws ClassNotFoundException {
+        ClassLoader classLoader = lookup.lookupClass().getClassLoader();
+        return Class.forName(name, true, classLoader);
+    }
 
     public static enum InvocationType {
         INVOKECONSTRUCTOR, INVOKESTATIC, INVOKEVIRTUAL, INVOKEINTERFACE, INVOKESPECIAL


### PR DESCRIPTION
The previous method bootstrap handler used to call `class.forName(String)`
to perform lookups. This causes classes to be loaded from the system
classloader and not from the one of the caller class.

This change uses `class.forName(String, boolean, ClassLoader)`. The correct
classloader is obtained through the lookup class context.
